### PR TITLE
Use items() instead of iteritems() to improve compatibility

### DIFF
--- a/roles/base/templates/hosts.j2
+++ b/roles/base/templates/hosts.j2
@@ -1,6 +1,6 @@
 127.0.0.1 localhost {{ hostname }} {{ hostname }}.{{ domain }}
 ::1       localhost {{ hostname }} {{ hostname }}.{{ domain }}
 
-{% for ip,hostnames in (etc_hosts | default({})).iteritems() %}
+{% for ip,hostnames in (etc_hosts | default({})).items() %}
 {{ ip }} {{ hostnames | join(' ') }}
 {% endfor %}

--- a/roles/nsd/templates/domain.zone.j2
+++ b/roles/nsd/templates/domain.zone.j2
@@ -45,7 +45,7 @@ git IN AAAA {{ ip6 }}
 dav IN A {{ ip }}
 dav IN AAAA {{ ip6 }}
 
-{% for name, record in (a_records | default({})).iteritems() %}
+{% for name, record in (a_records | default({})).items() %}
 {{ name }} IN A {{ record.ip }}
 {% if record.ip6 is defined %}
 {{ name }} IN AAAA {{ record.ip6 }}

--- a/roles/smtpd/templates/aliases.j2
+++ b/roles/smtpd/templates/aliases.j2
@@ -93,6 +93,6 @@ dumper: {{ username }}
 abuse:          root
 security:       root
 
-{% for address, recipients in (mail_aliases | default({})).iteritems() %}
+{% for address, recipients in (mail_aliases | default({})).items() %}
 {{ address }}: {{ ([recipients] if recipients is string else recipients) | join(', ') }}
 {% endfor %}

--- a/roles/spamd/templates/spamd.conf.j2
+++ b/roles/spamd/templates/spamd.conf.j2
@@ -4,7 +4,7 @@ all:\
 {% endfor %}
 
 
-{% for name, url in spamd_blacklists.iteritems() %}
+{% for name, url in spamd_blacklists.items() %}
 {{ name }}:\
 	:black:\
 	:msg="Blocked: your address %A is in the {{ name }} list":\


### PR DESCRIPTION
Recommendation in the Ansible docs:
https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems

I got this error on a fresh OpenBSD 3.6 install:
```..."AnsibleUndefinedVariable: `dict object` has no attribute `iteritems`"...```